### PR TITLE
Remove local workspace compatibility bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,40 +230,6 @@ The production recipes read `/etc/grafy/grafy.env` and merge
 `/etc/grafy/storage.override.yaml`; override those paths with
 `GRAFY_ENV_FILE` and `GRAFY_COMPOSE_OVERRIDE` when required.
 
-### Upgrade an existing Notarius checkout
-
-The Grafy release uses `GRAFY_*` environment variables. Rename every
-`NOTARIUS_*` key before starting the new code.
-
-Existing third-party Plugins must move their dependency and import names to
-`grafy-core` and `grafy_core`, then publish an immutable Workspace release. The
-old Python package and ambient host-loader namespaces are not retained as
-aliases.
-
-Local defaults reuse `.notarius-artifacts/workbench` and its
-`notarius.sqlite3` database only when the corresponding Grafy workspace or
-database does not exist. New installations write `.grafy-artifacts/workbench`
-and `grafy.sqlite3`. Legacy chunked table and JSON-collection manifests remain
-readable; new manifests use the `grafy.*` storage-format identifiers.
-
-For an existing Compose deployment, point `GRAFY_DATA_VOLUME` at the exact old
-Docker volume name and keep the existing SQLite filename in
-`GRAFY_DOCKER_DATABASE_URL` for the first Grafy deployment. Inspect the names
-before starting anything:
-
-```bash
-docker volume ls
-# Examples from the former local and production project names:
-GRAFY_DATA_VOLUME=notarius_notarius-data
-GRAFY_DATA_VOLUME=graphy_notarius-data
-GRAFY_DOCKER_DATABASE_URL=sqlite+aiosqlite:////data/workbench/notarius.sqlite3
-```
-
-After Grafy is healthy against the existing data, volume and database files
-may be renamed during a separately backed-up maintenance window. Do not let
-Compose create an empty `grafy-data` volume and mistake it for a successful
-migration.
-
 `just api` applies pending Alembic migrations before starting FastAPI. Saved
 graphs, artifact metadata, and materialization bindings are stored in SQLite at
 `.grafy-artifacts/workbench/grafy.sqlite3` by default, together with exact

--- a/apps/api/src/grafy_api/settings.py
+++ b/apps/api/src/grafy_api/settings.py
@@ -36,15 +36,6 @@ _OIDC_ALLOWED_ALGORITHMS = frozenset(
 
 STAGED_UPLOAD_HARD_MAX_BYTES = 64 * 1024 * 1024
 
-_DEFAULT_WORKSPACE = Path(".grafy-artifacts/workbench")
-_LEGACY_WORKSPACE = Path(".notarius-artifacts/workbench")
-
-
-def _default_workspace() -> Path:
-    if _DEFAULT_WORKSPACE.exists() or not _LEGACY_WORKSPACE.exists():
-        return _DEFAULT_WORKSPACE
-    return _LEGACY_WORKSPACE
-
 
 class Settings(BaseSettings):
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
@@ -54,7 +45,7 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    workspace: Path = Field(default_factory=_default_workspace)
+    workspace: Path = Path(".grafy-artifacts/workbench")
     public_origin: str = "http://localhost:3000"
     oidc_issuer: str | None = None
     oidc_client_id: str | None = None
@@ -305,9 +296,6 @@ class Settings(BaseSettings):
         if self.database_url is not None:
             return self.database_url.get_secret_value()
         database_path = (self.workspace / "grafy.sqlite3").resolve()
-        legacy_database_path = (self.workspace / "notarius.sqlite3").resolve()
-        if not database_path.exists() and legacy_database_path.exists():
-            database_path = legacy_database_path
         return f"sqlite+aiosqlite:///{database_path}"
 
     @property

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -306,19 +306,6 @@ the data workspace; a second owner fails closed. Do not add replicas, Uvicorn
 `--workers`, or shared room pubsub across processes until a separate design is
 accepted.
 
-## Legacy local-workspace upgrade
-
-New installations and installations with an empty legacy `local` workspace
-need no identity bootstrap. The first successful OIDC callback creates that
-user's personal workspace.
-
-If an older installation still has tenant data in an unowned `local`
-workspace, the migration fails without changing that workspace. Before
-deploying this release, run the previous release's documented
-`bootstrap-oidc-owner` command and complete the mapped owner's first login.
-The new migration then preserves the tenant as a normal shared workspace named
-`Migrated workspace`; it never deletes populated tenant data.
-
 ## Persistence, backup, and rollback
 
 The `grafy-data` volume contains the Grafy SQLite database, staged
@@ -373,7 +360,6 @@ a human on a real host/IdP/data copy.
 
 - [ ] Exact `GRAFY_PUBLIC_ORIGIN` and OIDC callback registered
 - [ ] Secrets generated and backed up outside the data volume
-- [ ] Any populated legacy `local` workspace has an active owner before upgrade
 - [ ] Plain HTTP gateway serves `/`, `/api/v1` on loopback `:8080` only
 - [ ] Separate TLS endpoint and both proxy hops validated for the public origin
 - [ ] One API replica / one worker; second owner fails startup

--- a/libs/core/src/grafy_core/domain/identity.py
+++ b/libs/core/src/grafy_core/domain/identity.py
@@ -11,9 +11,6 @@ from grafy_core.domain.errors import (
 )
 
 
-PERSONAL_WORKSPACE_SLUG_PREFIX = "personal-"
-
-
 class WorkspaceKind(StrEnum):
     PERSONAL = "personal"
     SHARED = "shared"
@@ -132,13 +129,7 @@ def normalize_workspace_slug(value: str) -> str:
             "Workspace slug must contain 1-80 lowercase letters, numbers, or "
             "internal hyphens"
         )
-    if slug == "local":
-        raise ValueError("Workspace slug 'local' is reserved")
     return slug
-
-
-def personal_workspace_slug(user_id: UUID) -> str:
-    return f"{PERSONAL_WORKSPACE_SLUG_PREFIX}{user_id.hex}"
 
 
 def capabilities_for_role(role: WorkspaceRole) -> frozenset[WorkspaceCapability]:
@@ -251,7 +242,7 @@ class Workspace:
     @classmethod
     def personal(cls, *, owner_user_id: UUID, name: str = "Personal") -> "Workspace":
         return cls(
-            slug=personal_workspace_slug(owner_user_id),
+            slug=owner_user_id.hex,
             name=name,
             kind=WorkspaceKind.PERSONAL,
             personal_owner_user_id=owner_user_id,
@@ -579,5 +570,4 @@ __all__ = [
     "capabilities_for_role",
     "ensure_last_owner_can_change",
     "normalize_workspace_slug",
-    "personal_workspace_slug",
 ]

--- a/tests/integration/collaboration/test_collaboration_acceptance.py
+++ b/tests/integration/collaboration/test_collaboration_acceptance.py
@@ -25,7 +25,6 @@ from grafy_core.domain.identity import (
     Workspace,
     WorkspaceKind,
     WorkspaceRole,
-    personal_workspace_slug,
 )
 from grafy_persistence.unit_of_work import SqlAlchemyUnitOfWork
 
@@ -78,7 +77,7 @@ def test_phase7_two_session_collaboration_acceptance_journey(
                 email="viewer@acceptance.test", display_name="Viewer"
             )
             personal = await seeder.workspace(
-                slug=personal_workspace_slug(owner.id),
+                slug=owner.id.hex,
                 name="Owner personal",
                 kind=WorkspaceKind.PERSONAL,
                 personal_owner_user_id=owner.id,

--- a/tests/unit/api/test_settings.py
+++ b/tests/unit/api/test_settings.py
@@ -11,26 +11,13 @@ from grafy_api.settings import Settings
 from grafy_api.plugin_egress import PluginEgressProtocol
 
 
-def test_default_workspace_reuses_legacy_data(
+def test_default_workspace_does_not_reuse_legacy_data(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     monkeypatch.chdir(tmp_path)
     legacy_workspace = tmp_path / ".notarius-artifacts" / "workbench"
     legacy_workspace.mkdir(parents=True)
-
-    settings = Settings(_env_file=None)  # pyright: ignore[reportCallIssue]
-
-    assert settings.workspace == Path(".notarius-artifacts/workbench")
-
-
-def test_default_workspace_prefers_grafy_when_both_exist(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / ".notarius-artifacts" / "workbench").mkdir(parents=True)
-    (tmp_path / ".grafy-artifacts" / "workbench").mkdir(parents=True)
 
     settings = Settings(_env_file=None)  # pyright: ignore[reportCallIssue]
 
@@ -99,7 +86,7 @@ def test_system_plugin_deployment_manifest_resolves_from_environment(
     assert settings.resolved_system_plugin_deployment_manifest == manifest.resolve()
 
 
-def test_database_url_reuses_legacy_database(tmp_path: Path) -> None:
+def test_database_url_does_not_reuse_legacy_database(tmp_path: Path) -> None:
     legacy_database = tmp_path / "notarius.sqlite3"
     legacy_database.touch()
 
@@ -108,9 +95,8 @@ def test_database_url_reuses_legacy_database(tmp_path: Path) -> None:
         workspace=tmp_path,
     )
 
-    assert settings.resolved_database_url == (
-        f"sqlite+aiosqlite:///{legacy_database.resolve()}"
-    )
+    expected_database = (tmp_path / "grafy.sqlite3").resolve()
+    assert settings.resolved_database_url == f"sqlite+aiosqlite:///{expected_database}"
 
 
 def test_execution_defaults_with_bounded_map_concurrency(

--- a/tests/unit/application/test_identity.py
+++ b/tests/unit/application/test_identity.py
@@ -210,12 +210,7 @@ async def test_oidc_provisioning_creates_only_a_personal_workspace(
         and event.resource_id == str(provisioned.user.id)
         for event in provisioning_events
     )
-    with pytest.raises(ValueError, match="slug 'local' is reserved"):
-        await service.create_shared_workspace(
-            actor=ActorContext(user_id=provisioned.user.id),
-            slug="local",
-            name="Local",
-        )
+
 
 @pytest.mark.asyncio
 async def test_personal_membership_stays_owner_and_membership_changes_are_audited(

--- a/tests/unit/core/test_identity.py
+++ b/tests/unit/core/test_identity.py
@@ -117,10 +117,17 @@ def test_personal_workspace_has_one_owner_shape() -> None:
         role=WorkspaceRole.OWNER,
     )
 
+    assert workspace.slug == owner_id.hex
     assert workspace.personal_owner_user_id == owner_id
     assert membership.grants(WorkspaceCapability.MANAGE_MEMBERS)
     with pytest.raises(IdentityInvariantError):
         Workspace(slug="personal", name="Bad", kind=WorkspaceKind.PERSONAL)
+
+
+def test_local_is_an_ordinary_shared_workspace_slug() -> None:
+    workspace = Workspace.shared(slug="local", name="Local")
+
+    assert workspace.slug == "local"
 
 
 def test_sensitive_credential_material_is_not_in_default_repr() -> None:

--- a/tests/unit/persistence/test_saved_graph_persistence.py
+++ b/tests/unit/persistence/test_saved_graph_persistence.py
@@ -46,7 +46,7 @@ async def database(tmp_path: Path) -> AsyncIterator[Database]:
             text(
                 "INSERT INTO workspaces "
                 "(id, slug, name, kind, created_at, updated_at) "
-                "VALUES (:id, 'local', 'Local', 'shared', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                "VALUES (:id, 'team', 'Team', 'shared', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
             ),
             {"id": WORKSPACE_ID.hex},
         )
@@ -61,8 +61,8 @@ async def database(tmp_path: Path) -> AsyncIterator[Database]:
         await connection.execute(
             text(
                 "INSERT INTO users "
-                "(id, active, created_at, updated_at) "
-                "VALUES (:id, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                "(id, active, email_verified, created_at, updated_at) "
+                "VALUES (:id, 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
             ),
             {"id": USER_ID.hex},
         )


### PR DESCRIPTION
## Summary

- use the owner UUID hex value as the personal workspace slug
- stop reserving the `local` workspace slug
- remove the Notarius workspace and database path fallbacks
- remove obsolete upgrade instructions and update affected fixtures

## Verification

- `uv run pytest tests/unit/core/test_identity.py tests/unit/application/test_identity.py tests/unit/api/test_settings.py tests/unit/persistence/test_saved_graph_persistence.py tests/integration/collaboration/test_collaboration_acceptance.py -q`
- `uv run ty check libs/core/src/grafy_core/domain/identity.py apps/api/src/grafy_api/settings.py`
- `uv run ruff check libs/core/src/grafy_core/domain/identity.py apps/api/src/grafy_api/settings.py tests/unit/core/test_identity.py tests/unit/application/test_identity.py tests/unit/api/test_settings.py tests/unit/persistence/test_saved_graph_persistence.py tests/integration/collaboration/test_collaboration_acceptance.py`
- `git diff --check`