### PR TITLE
feat(workbench): scope node browser by source with artifact and input filters

### DIFF
--- a/apps/web/src/features/workbench/model/node-catalog.test.ts
+++ b/apps/web/src/features/workbench/model/node-catalog.test.ts
@@ -6,15 +6,18 @@ import { portMetaForPort } from "../canvas/types";
 import {
   artifactFilterId,
   buildCatalogFilters,
+  buildSourceFilters,
   catalogNodeKey,
   catalogNodePortSummary,
   catalogNodeSpecs,
   catalogNodesForFilter,
   downstreamCandidatesFromOutput,
   filterAndSearchCatalogNodes,
+  INPUT_NODES_FILTER,
   moduleCallUpgradeTarget,
   pluginReleaseUpgradeTarget,
   sortCatalogNodes,
+  sourceFilterId,
   upstreamCandidatesFromInput,
 } from "./node-catalog";
 
@@ -361,7 +364,9 @@ describe("artifact catalog filters", () => {
   it("matches exact artifact, shape, any-artifact, and library filters", () => {
     const nodes = catalogNodeSpecs(registry(), null);
     const filters = buildCatalogFilters(registry());
-    const byId = Object.fromEntries(filters.map((filter) => [filter.id, filter]));
+    const byId = Object.fromEntries(
+      filters.map((filter) => [filter.id, filter]),
+    );
 
     expect(
       catalogNodesForFilter(
@@ -376,7 +381,9 @@ describe("artifact catalog filters", () => {
     ]);
 
     expect(
-      catalogNodesForFilter(nodes, byId.sequence!).map((spec) => spec.operator_id),
+      catalogNodesForFilter(nodes, byId.sequence!).map(
+        (spec) => spec.operator_id,
+      ),
     ).toEqual(["table.batch"]);
 
     expect(
@@ -412,7 +419,7 @@ describe("artifact catalog filters", () => {
     ]);
 
     expect(
-      filterAndSearchCatalogNodes(nodes, filter, "replace", registry()).map(
+      filterAndSearchCatalogNodes(nodes, [filter], "replace", registry()).map(
         (spec) => spec.operator_id,
       ),
     ).toEqual(["text.replace"]);
@@ -420,13 +427,76 @@ describe("artifact catalog filters", () => {
     expect(
       filterAndSearchCatalogNodes(
         nodes,
-        buildCatalogFilters(registry()).find(
-          (candidate) => candidate.id === "workspace-library",
-        )!,
+        [
+          buildCatalogFilters(registry()).find(
+            (candidate) => candidate.id === "workspace-library",
+          )!,
+        ],
         "normalize",
         registry(),
       ).map((spec) => spec.operator_id),
     ).toEqual([`module.graph.${FIRST_GRAPH_ID}`]);
+  });
+
+  it("builds one source category per provider plugin plus the workspace library", () => {
+    const sources = buildSourceFilters(registry());
+
+    expect(sources.map((filter) => [filter.id, filter.title])).toEqual([
+      ["all", "All"],
+      [sourceFilterId("builtin"), "Built-in"],
+      [sourceFilterId("external"), "External"],
+      ["workspace-library", "Workspace library"],
+    ]);
+  });
+
+  it("matches source and input-node filters", () => {
+    const nodes = catalogNodeSpecs(registry(), null);
+    const sources = buildSourceFilters(registry());
+    const byId = Object.fromEntries(
+      sources.map((filter) => [filter.id, filter]),
+    );
+
+    expect(
+      catalogNodesForFilter(nodes, byId[sourceFilterId("builtin")]!).map(
+        (spec) => spec.operator_id,
+      ),
+    ).toEqual(["text.input", "text.replace", "table.batch", "generic.pass"]);
+
+    // Nodes that take no inputs because they are inputs themselves.
+    expect(
+      catalogNodesForFilter(nodes, INPUT_NODES_FILTER).map(
+        (spec) => spec.operator_id,
+      ),
+    ).toEqual(["text.input", "ocr.external"]);
+  });
+
+  it("intersects source, artifact, and input-node filters", () => {
+    const nodes = catalogNodeSpecs(registry(), null);
+    const sources = buildSourceFilters(registry());
+    const builtin = sources.find((f) => f.id === sourceFilterId("builtin"))!;
+    const textArtifact = buildCatalogFilters(registry()).find(
+      (candidate) =>
+        candidate.id ===
+        artifactFilterId({ id: "scalar.text", schema_version: 1 }),
+    )!;
+
+    expect(
+      filterAndSearchCatalogNodes(
+        nodes,
+        [builtin, textArtifact],
+        "",
+        registry(),
+      ).map((spec) => spec.operator_id),
+    ).toEqual(["text.input", "text.replace"]);
+
+    expect(
+      filterAndSearchCatalogNodes(
+        nodes,
+        [builtin, textArtifact, INPUT_NODES_FILTER],
+        "",
+        registry(),
+      ).map((spec) => spec.operator_id),
+    ).toEqual(["text.input"]);
   });
 
   it("summarizes ports with artifact titles", () => {

--- a/apps/web/src/features/workbench/model/node-catalog.ts
+++ b/apps/web/src/features/workbench/model/node-catalog.ts
@@ -29,6 +29,8 @@ export type CatalogFilterKind =
   | "single"
   | "sequence"
   | "any-artifact"
+  | "source"
+  | "input-nodes"
   | "workspace-library";
 
 export type CatalogFilterId =
@@ -36,14 +38,18 @@ export type CatalogFilterId =
   | "single"
   | "sequence"
   | "any-artifact"
+  | "input-nodes"
   | "workspace-library"
-  | `artifact:${string}@${number}`;
+  | `artifact:${string}@${number}`
+  | `source:${string}`;
 
 export interface CatalogFilter {
   id: CatalogFilterId;
   kind: CatalogFilterKind;
   title: string;
   artifactKey?: ArtifactTypeKey;
+  /** Provider plugin slug, set for `source` filters. */
+  sourceKey?: string;
 }
 
 export interface ContextualRouteChoice {
@@ -77,6 +83,17 @@ export function artifactFilterId(key: ArtifactTypeKey): CatalogFilterId {
   return `artifact:${key.id}@${key.schema_version}`;
 }
 
+export function sourceFilterId(slug: string): CatalogFilterId {
+  return `source:${slug}`;
+}
+
+/** Restricts results to nodes that take no inputs because they are inputs themselves. */
+export const INPUT_NODES_FILTER: CatalogFilter = {
+  id: "input-nodes",
+  kind: "input-nodes",
+  title: "Input nodes",
+};
+
 function pluginFor(
   registry: NodeRegistry,
   slug: string,
@@ -97,7 +114,9 @@ function portDeclaresArtifact(port: Port, key: ArtifactTypeKey): boolean {
 }
 
 function portIsAnyArtifact(port: Port): boolean {
-  return portArtifactTypeVariable(port) != null && portArtifactType(port) == null;
+  return (
+    portArtifactTypeVariable(port) != null && portArtifactType(port) == null
+  );
 }
 
 function nodeDeclaresArtifact(spec: NodeSpec, key: ArtifactTypeKey): boolean {
@@ -106,10 +125,7 @@ function nodeDeclaresArtifact(spec: NodeSpec, key: ArtifactTypeKey): boolean {
   );
 }
 
-function nodeMatchesShapeFilter(
-  spec: NodeSpec,
-  shape: Port["shape"],
-): boolean {
+function nodeMatchesShapeFilter(spec: NodeSpec, shape: Port["shape"]): boolean {
   if (spec.outputs.some((port) => port.shape === shape)) return true;
   return spec.inputs.some((port) => acceptedPortShapes(port).includes(shape));
 }
@@ -119,13 +135,16 @@ function nodeMatchesAnyArtifact(spec: NodeSpec): boolean {
 }
 
 function isWorkspaceLibraryNode(spec: NodeSpec): boolean {
-  return Boolean(spec.module_graph_id || spec.plugin_slug === MODULE_PLUGIN_SLUG);
+  return Boolean(
+    spec.module_graph_id || spec.plugin_slug === MODULE_PLUGIN_SLUG,
+  );
 }
 
-function artifactTitle(
-  registry: NodeRegistry,
-  key: ArtifactTypeKey,
-): string {
+function isInputNode(spec: NodeSpec): boolean {
+  return spec.inputs.length === 0;
+}
+
+function artifactTitle(registry: NodeRegistry, key: ArtifactTypeKey): string {
   return (
     registry.artifact_types.find(
       (artifact) =>
@@ -135,16 +154,50 @@ function artifactTitle(
   );
 }
 
+/** Build the source categories: every provider plugin that ships nodes, plus the workspace library. */
+export function buildSourceFilters(
+  registry: NodeRegistry,
+): readonly CatalogFilter[] {
+  const slugsWithNodes = new Set(
+    registry.nodes.map((spec) => spec.plugin_slug),
+  );
+  const sources = registry.plugins
+    .filter(
+      (plugin) =>
+        plugin.entry_kind !== "module" && slugsWithNodes.has(plugin.slug),
+    )
+    .slice()
+    .sort(
+      (left, right) =>
+        left.title.localeCompare(right.title) ||
+        left.slug.localeCompare(right.slug),
+    );
+
+  return [
+    { id: "all", kind: "all", title: "All" },
+    ...sources.map(
+      (plugin): CatalogFilter => ({
+        id: sourceFilterId(plugin.slug),
+        kind: "source",
+        title: plugin.title || "System",
+        sourceKey: plugin.slug,
+      }),
+    ),
+    {
+      id: "workspace-library",
+      kind: "workspace-library",
+      title: "Workspace library",
+    },
+  ];
+}
+
 /** Build browse filters from registered artifact types plus fixed shape/library filters. */
 export function buildCatalogFilters(
   registry: NodeRegistry,
 ): readonly CatalogFilter[] {
   const titleCounts = new Map<string, number>();
   for (const artifact of registry.artifact_types) {
-    titleCounts.set(
-      artifact.title,
-      (titleCounts.get(artifact.title) ?? 0) + 1,
-    );
+    titleCounts.set(artifact.title, (titleCounts.get(artifact.title) ?? 0) + 1);
   }
 
   const artifactFilters = [...registry.artifact_types]
@@ -191,7 +244,9 @@ export function catalogNodesForFilter(
       return nodes;
     case "artifact":
       return filter.artifactKey
-        ? nodes.filter((spec) => nodeDeclaresArtifact(spec, filter.artifactKey!))
+        ? nodes.filter((spec) =>
+            nodeDeclaresArtifact(spec, filter.artifactKey!),
+          )
         : [];
     case "single":
       return nodes.filter((spec) => nodeMatchesShapeFilter(spec, "one"));
@@ -199,6 +254,12 @@ export function catalogNodesForFilter(
       return nodes.filter((spec) => nodeMatchesShapeFilter(spec, "many"));
     case "any-artifact":
       return nodes.filter(nodeMatchesAnyArtifact);
+    case "source":
+      return filter.sourceKey
+        ? nodes.filter((spec) => spec.plugin_slug === filter.sourceKey)
+        : [];
+    case "input-nodes":
+      return nodes.filter(isInputNode);
     case "workspace-library":
       return nodes.filter(isWorkspaceLibraryNode);
   }
@@ -272,13 +333,16 @@ export function searchCatalogNodes(
 
 export function filterAndSearchCatalogNodes(
   nodes: readonly NodeSpec[],
-  filter: CatalogFilter,
+  filters: readonly CatalogFilter[],
   query: string,
   registry: NodeRegistry,
 ): readonly NodeSpec[] {
-  return sortCatalogNodes(
-    searchCatalogNodes(catalogNodesForFilter(nodes, filter), query, registry),
+  const filtered = filters.reduce(
+    (acc, filter) =>
+      filter.kind === "all" ? acc : catalogNodesForFilter(acc, filter),
+    nodes,
   );
+  return sortCatalogNodes(searchCatalogNodes(filtered, query, registry));
 }
 
 export function catalogNodeSpecs(
@@ -343,7 +407,11 @@ export function moduleReleaseSpecs(
   return registry.nodes
     .filter((spec) => {
       if (moduleId && spec.module_id === moduleId) return true;
-      if (!moduleId && moduleGraphId && spec.module_graph_id === moduleGraphId) {
+      if (
+        !moduleId &&
+        moduleGraphId &&
+        spec.module_graph_id === moduleGraphId
+      ) {
         return true;
       }
       return false;
@@ -481,10 +549,7 @@ export function downstreamCandidatesFromOutput(options: {
         artifactTypes,
         conversions,
       );
-      const routes = routesForHandleFeed(
-        allRoutes,
-        sourceFeed ?? undefined,
-      );
+      const routes = routesForHandleFeed(allRoutes, sourceFeed ?? undefined);
       for (const route of routes) {
         choices.push({
           candidatePort: input as Port & { readonly direction: "input" },
@@ -582,14 +647,14 @@ function portsCanConnect(
 ): boolean {
   if (!shapesAreCompatible(source, target)) return false;
   if (portHasInstancePlugs(target) && !target.required) return false;
-  const plugId = portHasInstancePlugs(target)
-    ? "discovery-plug"
-    : undefined;
+  const plugId = portHasInstancePlugs(target) ? "discovery-plug" : undefined;
   return (
     connectionRoutesFor(
       {
         sourceHandle: encodeHandleId(portMetaForPort(source)),
-        targetHandle: encodeHandleId(portMetaForPort(target, target.shape, plugId)),
+        targetHandle: encodeHandleId(
+          portMetaForPort(target, target.shape, plugId),
+        ),
       },
       registry.artifact_types,
       registry.artifact_conversions,

--- a/apps/web/src/features/workbench/ui/NodeSelector.test.tsx
+++ b/apps/web/src/features/workbench/ui/NodeSelector.test.tsx
@@ -157,30 +157,53 @@ function registry(): NodeRegistry {
           },
         },
       }),
-      node("text.replace", "Replace text", "builtin", [textInput], [textOutput], {
-        config_schema: {
-          type: "object",
-          properties: {
-            replacement: {
-              type: "string",
-              title: "Replacement",
-              description: "Replacement text",
+      node(
+        "text.replace",
+        "Replace text",
+        "builtin",
+        [textInput],
+        [textOutput],
+        {
+          config_schema: {
+            type: "object",
+            properties: {
+              replacement: {
+                type: "string",
+                title: "Replacement",
+                description: "Replacement text",
+              },
             },
           },
         },
-      }),
-      node("table.fuzzy_match", "Fuzzy match tables", "builtin", [tableInput], [tableOutput]),
-      node("gis.map.compose", "Compose map", "builtin", [layerInput], [mapOutput]),
+      ),
+      node(
+        "table.fuzzy_match",
+        "Fuzzy match tables",
+        "builtin",
+        [tableInput],
+        [tableOutput],
+      ),
+      node(
+        "gis.map.compose",
+        "Compose map",
+        "builtin",
+        [layerInput],
+        [mapOutput],
+      ),
       firstModuleRelease,
       currentModuleRelease,
-      node("ocr.pages", "Read image with OCR", "external.ocr", [imageInput], [textOutput]),
+      node(
+        "ocr.pages",
+        "Read image with OCR",
+        "external.ocr",
+        [imageInput],
+        [textOutput],
+      ),
     ],
   };
 }
 
-async function renderSelector(
-  overrides: Partial<NodeSelectorProps> = {},
-) {
+async function renderSelector(overrides: Partial<NodeSelectorProps> = {}) {
   const container = document.createElement("div");
   document.body.append(container);
   const root = createRoot(container);
@@ -201,7 +224,14 @@ async function renderSelector(
     });
   };
   await render();
-  return { container, root, render, get props() { return props; } };
+  return {
+    container,
+    root,
+    render,
+    get props() {
+      return props;
+    },
+  };
 }
 
 function dialog(): HTMLElement {
@@ -211,7 +241,9 @@ function dialog(): HTMLElement {
 }
 
 function searchInput(): HTMLInputElement {
-  const input = dialog().querySelector<HTMLInputElement>('[aria-label="Search nodes"]');
+  const input = dialog().querySelector<HTMLInputElement>(
+    '[aria-label="Search nodes"]',
+  );
   if (!input) throw new Error("Node search was not rendered");
   return input;
 }
@@ -221,7 +253,9 @@ function options(): HTMLButtonElement[] {
 }
 
 function buttonNamed(name: string): HTMLButtonElement {
-  const button = [...dialog().querySelectorAll<HTMLButtonElement>("button")].find(
+  const button = [
+    ...dialog().querySelectorAll<HTMLButtonElement>("button"),
+  ].find(
     (candidate) =>
       candidate.textContent?.trim() === name ||
       candidate.getAttribute("aria-label") === name,
@@ -260,7 +294,7 @@ afterEach(async () => {
 });
 
 describe("NodeSelector", () => {
-  it("uses the mockup artifact-family rail", async () => {
+  it("scopes the rail by source with artifact and input-node refinements", async () => {
     await renderSelector();
 
     expect(
@@ -269,22 +303,54 @@ describe("NodeSelector", () => {
         ?.getAttribute("aria-orientation"),
     ).toBe("vertical");
     const filters = [
-      ...dialog().querySelectorAll<HTMLButtonElement>('[role="toolbar"] button'),
+      ...dialog().querySelectorAll<HTMLButtonElement>(
+        '[role="toolbar"] button',
+      ),
     ];
     expect(filters.map((filter) => filter.textContent)).toEqual([
       "All",
-      "Text",
-      "Images",
-      "Tables",
-      "Spatial",
-      "Prompts",
-      "Sequences",
+      "Built-in",
+      "OCR",
       "Workspace library",
     ]);
 
-    await React.act(async () => buttonNamed("Text, 4 nodes").click());
-    expect(dialog().textContent).toContain("Text nodes");
-    expect(options()).toHaveLength(4);
+    // Source category scopes the list to one provider plugin.
+    await React.act(async () => buttonNamed("Built-in, 4 nodes").click());
+    expect(dialog().textContent).toContain("Built-in nodes");
+    expect(options().map((option) => option.textContent)).toEqual([
+      expect.stringContaining("Compose map"),
+      expect.stringContaining("Enter text"),
+      expect.stringContaining("Fuzzy match tables"),
+      expect.stringContaining("Replace text"),
+    ]);
+
+    // The artifact type refines within the active source.
+    const artifactSelect = dialog().querySelector<HTMLSelectElement>(
+      '[aria-label="Artifact type"]',
+    );
+    expect(artifactSelect).not.toBeNull();
+    await React.act(async () => {
+      if (!artifactSelect) return;
+      artifactSelect.value = "artifact:scalar.text@1";
+      artifactSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(options().map((option) => option.textContent)).toEqual([
+      expect.stringContaining("Enter text"),
+      expect.stringContaining("Replace text"),
+    ]);
+
+    // Input nodes only: nodes that take no inputs because they are inputs themselves.
+    const inputToggle = dialog().querySelector<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    expect(inputToggle).not.toBeNull();
+    await React.act(async () => {
+      inputToggle?.click();
+    });
+    expect(inputToggle?.checked).toBe(true);
+    expect(options().map((option) => option.textContent)).toEqual([
+      expect.stringContaining("Enter text"),
+    ]);
   });
 
   it("searches the full registry and inspects a result without inserting it", async () => {
@@ -428,13 +494,17 @@ describe("NodeSelector", () => {
     await enterSearch("Replace text");
     await React.act(async () => options()[0]?.click());
 
-    expect(dialog().querySelector("aside")?.textContent).toContain("Works with:");
+    expect(dialog().querySelector("aside")?.textContent).toContain(
+      "Works with:",
+    );
     const portSelect = dialog().querySelector<HTMLSelectElement>(
       '[aria-label="Works with port"]',
     );
     expect(portSelect?.value).toBe("input:text");
     expect(portSelect?.selectedOptions[0]?.textContent).toBe("Text input");
-    expect(dialog().querySelector("aside")?.textContent).toContain("Enter text");
+    expect(dialog().querySelector("aside")?.textContent).toContain(
+      "Enter text",
+    );
 
     await React.act(async () => {
       if (!portSelect) return;
@@ -444,13 +514,16 @@ describe("NodeSelector", () => {
     expect(portSelect?.value).toBe("output:text");
     expect(portSelect?.selectedOptions[0]?.textContent).toBe("Text output");
 
-    await React.act(async () => buttonNamed("Inspect Normalize invoices").click());
+    await React.act(async () =>
+      buttonNamed("Inspect Normalize invoices").click(),
+    );
     expect(dialog().querySelector("aside")?.textContent).toContain(
       "Module contract · release 2",
     );
     expect(
-      options().find((option) => option.getAttribute("aria-selected") === "true")
-        ?.textContent,
+      options().find(
+        (option) => option.getAttribute("aria-selected") === "true",
+      )?.textContent,
     ).toContain("Normalize invoices");
   });
 
@@ -488,7 +561,9 @@ describe("NodeSelector", () => {
     vi.spyOn(window, "confirm").mockReturnValue(true);
     await renderSelector({ onAddNode, onOpenGraph });
 
-    await React.act(async () => buttonNamed("Workspace library, 1 node").click());
+    await React.act(async () =>
+      buttonNamed("Workspace library, 1 node").click(),
+    );
     expect(options()[0]?.textContent).toContain("Normalize invoices");
     expect(dialog().querySelector("aside")?.textContent).toContain(
       "Module contract · release 2",
@@ -526,7 +601,9 @@ describe("NodeSelector", () => {
       onOpenWorkspaceLibrary,
     });
 
-    await React.act(async () => buttonNamed("Workspace library, 0 nodes").click());
+    await React.act(async () =>
+      buttonNamed("Workspace library, 0 nodes").click(),
+    );
     expect(options()).toHaveLength(0);
     expect(dialog().textContent).toContain(
       "No published Modules in this workspace yet.",
@@ -543,12 +620,16 @@ describe("NodeSelector", () => {
     expect(dialog().querySelector('[role="status"]')?.textContent).toBe(
       "No nodes found.",
     );
-    expect(dialog().textContent).toContain("No nodes match the current search or filter.");
+    expect(dialog().textContent).toContain(
+      "No nodes match the current search or filter.",
+    );
     await React.act(async () => buttonNamed("Reset search and filter").click());
 
     expect(searchInput().value).toBe("");
     expect(options().length).toBeGreaterThan(0);
-    expect(buttonNamed("All, 6 nodes").getAttribute("aria-pressed")).toBe("true");
+    expect(buttonNamed("All, 6 nodes").getAttribute("aria-pressed")).toBe(
+      "true",
+    );
   });
 
   it("announces counts, loading, errors, and recovery atomically", async () => {
@@ -556,7 +637,9 @@ describe("NodeSelector", () => {
     const rendered = await renderSelector();
 
     const status = dialog().querySelector('[role="status"]');
-    expect(dialog().getAttribute("aria-labelledby")).toBe("node-selector-title");
+    expect(dialog().getAttribute("aria-labelledby")).toBe(
+      "node-selector-title",
+    );
     expect(dialog().getAttribute("aria-describedby")).toBe(
       "node-selector-description",
     );
@@ -564,9 +647,9 @@ describe("NodeSelector", () => {
       "node-selector-results",
     );
     expect(
-      dialog().querySelector('[role="listbox"]')?.getAttribute(
-        "aria-activedescendant",
-      ),
+      dialog()
+        .querySelector('[role="listbox"]')
+        ?.getAttribute("aria-activedescendant"),
     ).toBe(options()[0]?.id);
     expect(options()[0]?.getAttribute("aria-selected")).toBe("true");
     expect(status?.getAttribute("aria-live")).toBe("polite");
@@ -577,7 +660,9 @@ describe("NodeSelector", () => {
     expect(dialog().querySelector('[role="status"]')?.textContent).toBe(
       "Loading nodes…",
     );
-    expect(dialog().querySelector('[role="listbox"]')?.getAttribute("aria-busy")).toBe("true");
+    expect(
+      dialog().querySelector('[role="listbox"]')?.getAttribute("aria-busy"),
+    ).toBe("true");
 
     await rendered.render({
       loading: false,
@@ -596,11 +681,14 @@ describe("NodeSelector", () => {
   it("uses one roving filter stop and exposes permission-disabled insertion", async () => {
     await renderSelector({
       canInsert: false,
-      insertDisabledReason: "Viewers can inspect nodes but cannot edit this graph.",
+      insertDisabledReason:
+        "Viewers can inspect nodes but cannot edit this graph.",
     });
 
     const filters = [
-      ...dialog().querySelectorAll<HTMLButtonElement>('[role="toolbar"] button'),
+      ...dialog().querySelectorAll<HTMLButtonElement>(
+        '[role="toolbar"] button',
+      ),
     ];
     expect(filters.filter((button) => button.tabIndex === 0)).toHaveLength(1);
     filters[0]?.focus();

--- a/apps/web/src/features/workbench/ui/NodeSelector.tsx
+++ b/apps/web/src/features/workbench/ui/NodeSelector.tsx
@@ -5,20 +5,14 @@ import * as stylex from "@stylexjs/stylex";
 import {
   ArrowDownToLine,
   ArrowUpFromLine,
-  Box,
   Cable,
   ExternalLink,
-  Database,
-  Image as ImageIcon,
   LayoutGrid,
   LibraryBig,
-  MapPin,
+  Package,
   Plus,
   Search,
   Settings2,
-  Sparkles,
-  Table2,
-  Type,
   Workflow,
 } from "lucide-react";
 
@@ -48,45 +42,25 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog";
-import type {
-  NodeRegistry,
-  NodeSpec,
-  Port,
-} from "@/lib/api";
-import {
-  FINE_POINTER_QUERY,
-  useMediaQuery,
-} from "@/hooks/use-media-query";
+import type { NodeRegistry, NodeSpec, Port } from "@/lib/api";
+import { FINE_POINTER_QUERY, useMediaQuery } from "@/hooks/use-media-query";
 import { tokens } from "@/lib/stylex/tokens.stylex";
 import {
   buildCatalogFilters,
+  buildSourceFilters,
   catalogNodeKey,
   catalogNodeSpecs,
   filterAndSearchCatalogNodes,
+  INPUT_NODES_FILTER,
   moduleReleaseSpecs,
   nodesCompatibleWithPort,
+  sourceFilterId,
   sortCatalogNodes,
   type CatalogFilter,
 } from "../model/node-catalog";
 
 const MODULE_PLUGIN_SLUG = "graph.module";
 const MOBILE_NODE_SELECTOR_QUERY = "(max-width: 720px)";
-
-type BrowserFilterId =
-  | "all"
-  | "text"
-  | "images"
-  | "tables"
-  | "spatial"
-  | "prompts"
-  | "sequences"
-  | "workspace-library";
-
-interface BrowserFilter {
-  id: BrowserFilterId;
-  title: string;
-  sourceFilters: readonly CatalogFilter[];
-}
 
 /** A port-scoped Add node invocation using the same routes as canvas wiring. */
 export type NodeSelectorCompatibilityContext =
@@ -203,13 +177,14 @@ function compatibleNodesForPort(
   const selectedKey = nodeKey(selected);
   const matches = registry.nodes.flatMap((candidate) => {
     if (nodeKey(candidate) === selectedKey) return [];
-    const pairs = port.direction === "input"
-      ? compatiblePortPairs(candidate, selected, registry).filter(
-          (pair) => pair.target.name === port.name,
-        )
-      : compatiblePortPairs(selected, candidate, registry).filter(
-          (pair) => pair.source.name === port.name,
-        );
+    const pairs =
+      port.direction === "input"
+        ? compatiblePortPairs(candidate, selected, registry).filter(
+            (pair) => pair.target.name === port.name,
+          )
+        : compatiblePortPairs(selected, candidate, registry).filter(
+            (pair) => pair.source.name === port.name,
+          );
     const first = pairs[0];
     if (!first) return [];
 
@@ -230,11 +205,13 @@ function compatibleNodesForPort(
       (count, pair) => count + pair.routeCount,
       0,
     );
-    return [{
-      spec: candidate,
-      routeSummary,
-      additionalRouteCount: totalRouteCount - 1,
-    }];
+    return [
+      {
+        spec: candidate,
+        routeSummary,
+        additionalRouteCount: totalRouteCount - 1,
+      },
+    ];
   });
   const order = new Map(
     sortCatalogNodes(matches.map((match) => match.spec)).map((spec, index) => [
@@ -244,7 +221,8 @@ function compatibleNodesForPort(
   );
   return matches.sort(
     (left, right) =>
-      (order.get(nodeKey(left.spec)) ?? 0) - (order.get(nodeKey(right.spec)) ?? 0),
+      (order.get(nodeKey(left.spec)) ?? 0) -
+      (order.get(nodeKey(right.spec)) ?? 0),
   );
 }
 
@@ -289,98 +267,10 @@ function fieldConstraintLabel(field: SchemaField): string {
   return constraints.join(" · ");
 }
 
-function buildBrowserFilters(filters: readonly CatalogFilter[]): BrowserFilter[] {
-  const artifactFilters = filters.filter((filter) => filter.kind === "artifact");
-
-  return [
-    {
-      id: "all",
-      title: "All",
-      sourceFilters: filters.filter((filter) => filter.kind === "all"),
-    },
-    {
-      id: "text",
-      title: "Text",
-      sourceFilters: artifactFilters.filter(
-        (filter) => filter.artifactKey && (
-          filter.artifactKey.id === "scalar.text" ||
-          filter.artifactKey.id.startsWith("text.")
-        ),
-      ),
-    },
-    {
-      id: "images",
-      title: "Images",
-      sourceFilters: artifactFilters.filter(
-        (filter) => filter.artifactKey?.id.startsWith("image."),
-      ),
-    },
-    {
-      id: "tables",
-      title: "Tables",
-      sourceFilters: artifactFilters.filter(
-        (filter) => filter.artifactKey?.id.startsWith("table."),
-      ),
-    },
-    {
-      id: "spatial",
-      title: "Spatial",
-      sourceFilters: artifactFilters.filter(
-        (filter) => filter.artifactKey?.id.startsWith("geo."),
-      ),
-    },
-    {
-      id: "prompts",
-      title: "Prompts",
-      sourceFilters: artifactFilters.filter(
-        (filter) => filter.artifactKey?.id.startsWith("prompt."),
-      ),
-    },
-    {
-      id: "sequences",
-      title: "Sequences",
-      sourceFilters: filters.filter((filter) => filter.kind === "sequence"),
-    },
-    {
-      id: "workspace-library",
-      title: "Workspace library",
-      sourceFilters: filters.filter(
-        (filter) => filter.kind === "workspace-library",
-      ),
-    },
-  ];
-}
-
-function nodesForBrowserFilter(
-  nodes: readonly NodeSpec[],
-  filter: BrowserFilter,
-  query: string,
-  registry: NodeRegistry,
-): NodeSpec[] {
-  const unique = new Map<string, NodeSpec>();
-  for (const sourceFilter of filter.sourceFilters) {
-    for (const spec of filterAndSearchCatalogNodes(
-      nodes,
-      sourceFilter,
-      query,
-      registry,
-    )) {
-      unique.set(nodeKey(spec), spec);
-    }
-  }
-  return sortCatalogNodes([...unique.values()]);
-}
-
-function BrowserFilterIcon({ filter }: { filter: BrowserFilter }) {
+function SourceFilterIcon({ filter }: { filter: CatalogFilter }) {
   if (filter.id === "all") return <LayoutGrid size={14} />;
-  if (filter.id === "text") return <Type size={14} />;
-  if (filter.id === "images") return <ImageIcon size={14} />;
-  if (filter.id === "tables") return <Table2 size={14} />;
-  if (filter.id === "spatial") return <MapPin size={14} />;
-  if (filter.id === "prompts") return <Sparkles size={14} />;
-  if (filter.id === "sequences") return <Database size={14} />;
   if (filter.id === "workspace-library") return <LibraryBig size={14} />;
-  return <Box size={14} />;
+  return <Package size={14} />;
 }
 
 const s = stylex.create({
@@ -467,9 +357,9 @@ const s = stylex.create({
     gridTemplateRows: {
       default: "minmax(0, 1fr)",
       "@media (max-width: 1080px)": "minmax(280px, 1fr) minmax(280px, 0.9fr)",
-      "@media (min-width: 720.01px) and (max-height: 620px)":
-        "minmax(0, 1fr)",
-      "@media (max-width: 720px)": "auto minmax(280px, 46svh) minmax(420px, 72svh)",
+      "@media (min-width: 720.01px) and (max-height: 620px)": "minmax(0, 1fr)",
+      "@media (max-width: 720px)":
+        "auto minmax(280px, 46svh) minmax(420px, 72svh)",
     },
     gridTemplateAreas: {
       default: '"filters nodes inspector"',
@@ -568,6 +458,58 @@ const s = stylex.create({
     },
     borderTopStyle: "solid",
     borderTopColor: tokens.colorBorder,
+  },
+  refinementSection: {
+    marginTop: {
+      default: "12px",
+      "@media (max-width: 720px)": 0,
+    },
+    paddingTop: {
+      default: "12px",
+      "@media (max-width: 720px)": 0,
+    },
+    borderTopWidth: {
+      default: 1,
+      "@media (max-width: 720px)": 0,
+    },
+    borderTopStyle: "solid",
+    borderTopColor: tokens.colorBorder,
+    display: "grid",
+    gap: "10px",
+    paddingInline: "10px",
+  },
+  refinementField: {
+    display: "grid",
+    gap: "4px",
+    color: tokens.colorSubtle,
+    fontSize: tokens.fontSizeXs,
+    fontWeight: 730,
+  },
+  refinementSelect: {
+    width: "100%",
+    minHeight: "32px",
+    padding: "0 8px",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: tokens.colorBorderStrong,
+    borderRadius: tokens.radiusSm,
+    backgroundColor: tokens.colorSurfaceSunken,
+    color: tokens.colorText,
+    fontSize: tokens.fontSizeSm,
+    cursor: "pointer",
+    outlineColor: tokens.colorAccent,
+    outlineStyle: "solid",
+    outlineOffset: "2px",
+    outlineWidth: { default: 0, ":focus-visible": "2px" },
+  },
+  refinementCheck: {
+    display: "flex",
+    alignItems: "center",
+    gap: "7px",
+    color: tokens.colorSubtle,
+    fontSize: tokens.fontSizeXs,
+    fontWeight: 640,
+    cursor: "pointer",
   },
   nodePane: {
     gridArea: "nodes",
@@ -1093,7 +1035,11 @@ const s = stylex.create({
     borderBottomColor: tokens.colorDivider,
   },
   fieldIdentity: { minWidth: 0 },
-  fieldTitle: { color: tokens.colorText, fontSize: tokens.fontSizeSm, fontWeight: 690 },
+  fieldTitle: {
+    color: tokens.colorText,
+    fontSize: tokens.fontSizeSm,
+    fontWeight: 690,
+  },
   fieldName: {
     marginTop: "2px",
     overflow: "hidden",
@@ -1148,7 +1094,10 @@ const s = stylex.create({
     overflow: "hidden",
     borderWidth: 0,
     borderRadius: tokens.radiusSm,
-    backgroundColor: { default: tokens.colorAccent, ":hover": tokens.colorAccentHover },
+    backgroundColor: {
+      default: tokens.colorAccent,
+      ":hover": tokens.colorAccentHover,
+    },
     color: tokens.colorOnAccent,
     cursor: "pointer",
     outlineColor: tokens.colorAccent,
@@ -1201,7 +1150,8 @@ function CompatibilityList({
                 {match.spec.title}
               </span>
               <span {...stylex.props(s.compatibilityMeta)}>
-                {pluginFor(registry, match.spec.plugin_slug).title} · {match.routeSummary}
+                {pluginFor(registry, match.spec.plugin_slug).title} ·{" "}
+                {match.routeSummary}
                 {match.additionalRouteCount > 0
                   ? ` · +${match.additionalRouteCount} route${match.additionalRouteCount === 1 ? "" : "s"}`
                   : ""}
@@ -1271,9 +1221,11 @@ function WorksWithSection({
       <CompatibilityList
         matches={matches}
         registry={registry}
-        emptyMessage={receiving
-          ? "No registered node currently provides a compatible output."
-          : "No registered node currently accepts this output."}
+        emptyMessage={
+          receiving
+            ? "No registered node currently provides a compatible output."
+            : "No registered node currently accepts this output."
+        }
         onInspect={onInspect}
       />
     </section>
@@ -1301,11 +1253,9 @@ function PortList({ direction, ports, registry }: PortListProps) {
             const variable = portArtifactTypeVariable(port);
             const contract = artifactType
               ? `${artifactType.id}@${artifactType.schema_version}`
-              : variable ?? "generic";
+              : (variable ?? "generic");
             const acceptedShapeRule = acceptedPortShapes(port)
-              .map((shape) =>
-                shape === "many" ? "sequence" : "single value",
-              )
+              .map((shape) => (shape === "many" ? "sequence" : "single value"))
               .join(" or ");
             const rules = [
               port.required ? "required" : "optional",
@@ -1315,9 +1265,14 @@ function PortList({ direction, ports, registry }: PortListProps) {
                 : port.variadic
                   ? "multiple connections"
                   : null,
-            ].filter(Boolean).join(" · ");
+            ]
+              .filter(Boolean)
+              .join(" · ");
             return (
-              <div key={`${direction}-${port.name}`} {...stylex.props(s.portRow)}>
+              <div
+                key={`${direction}-${port.name}`}
+                {...stylex.props(s.portRow)}
+              >
                 <span
                   aria-hidden="true"
                   {...stylex.props(s.portDot)}
@@ -1336,7 +1291,9 @@ function PortList({ direction, ports, registry }: PortListProps) {
                   </div>
                   <div {...stylex.props(s.portRules)}>{rules}</div>
                   {port.description ? (
-                    <p {...stylex.props(s.portDescription)}>{port.description}</p>
+                    <p {...stylex.props(s.portDescription)}>
+                      {port.description}
+                    </p>
                   ) : null}
                 </div>
               </div>
@@ -1345,7 +1302,9 @@ function PortList({ direction, ports, registry }: PortListProps) {
         </div>
       ) : (
         <p {...stylex.props(s.compatibilityEmpty)}>
-          {input ? "No inputs. This node can start a workflow." : "No outputs. This node finishes a branch."}
+          {input
+            ? "No inputs. This node can start a workflow."
+            : "No outputs. This node finishes a branch."}
         </p>
       )}
     </div>
@@ -1371,8 +1330,14 @@ export function NodeSelector({
   const mobileNodeSelector = useMediaQuery(MOBILE_NODE_SELECTOR_QUERY);
   const finePointer = useMediaQuery(FINE_POINTER_QUERY);
   const [query, setQuery] = React.useState("");
-  const [filterId, setFilterId] = React.useState<BrowserFilterId>("all");
-  const [selectedNodeKey, setSelectedNodeKey] = React.useState<string | null>(null);
+  const [activeSourceId, setActiveSourceId] = React.useState<string>("all");
+  const [artifactFilterId, setArtifactFilterId] = React.useState<string | null>(
+    null,
+  );
+  const [inputNodesOnly, setInputNodesOnly] = React.useState(false);
+  const [selectedNodeKey, setSelectedNodeKey] = React.useState<string | null>(
+    null,
+  );
   const [selectedRelease, setSelectedRelease] = React.useState<{
     moduleKey: string;
     releaseKey: string;
@@ -1381,7 +1346,7 @@ export function NodeSelector({
   const [compatibilityPortSelection, setCompatibilityPortSelection] =
     React.useState<{ specKey: string; portKey: string } | null>(null);
   const resultRefs = React.useRef(new Map<string, HTMLButtonElement>());
-  const filterRefs = React.useRef(new Map<BrowserFilterId, HTMLButtonElement>());
+  const filterRefs = React.useRef(new Map<string, HTMLButtonElement>());
   const dialogRef = React.useRef<HTMLDivElement>(null);
   const searchRef = React.useRef<HTMLInputElement>(null);
   const pendingResultFocusKey = React.useRef<string | null>(null);
@@ -1391,37 +1356,51 @@ export function NodeSelector({
     () => buildCatalogFilters(registry),
     [registry],
   );
-  const browserFilters = React.useMemo(
-    () => buildBrowserFilters(catalogFilters),
+  const sourceFilters = React.useMemo(
+    () => buildSourceFilters(registry),
+    [registry],
+  );
+  const artifactOptions = React.useMemo(
+    () => catalogFilters.filter((filter) => filter.kind === "artifact"),
     [catalogFilters],
   );
-  const activeFilter =
-    browserFilters.find((filter) => filter.id === filterId) ??
-    browserFilters[0]!;
+  const activeSourceFilter =
+    sourceFilters.find((filter) => filter.id === activeSourceId) ??
+    sourceFilters[0]!;
+  const activeArtifactFilter =
+    artifactOptions.find((filter) => filter.id === artifactFilterId) ?? null;
+  const refinementFilters = React.useMemo(
+    () => [
+      ...(activeArtifactFilter ? [activeArtifactFilter] : []),
+      ...(inputNodesOnly ? [INPUT_NODES_FILTER] : []),
+    ],
+    [activeArtifactFilter, inputNodesOnly],
+  );
 
   const catalogNodes = React.useMemo(
     () => catalogNodeSpecs(registry, activeGraphId),
     [activeGraphId, registry],
   );
   const compatibleCatalogNodes = React.useMemo(
-    () => compatibility
-      ? nodesCompatibleWithPort(catalogNodes, compatibility, registry)
-      : catalogNodes,
+    () =>
+      compatibility
+        ? nodesCompatibleWithPort(catalogNodes, compatibility, registry)
+        : catalogNodes,
     [catalogNodes, compatibility, registry],
   );
   const catalogRegistry = React.useMemo(
     () => ({ ...registry, nodes: catalogNodes }),
     [catalogNodes, registry],
   );
-  const showingModules = activeFilter.id === "workspace-library";
+  const showingModules = activeSourceId === "workspace-library";
   const activeEditingModule = React.useMemo(
     () =>
       activeGraphId
-        ? registry.nodes.find(
+        ? (registry.nodes.find(
             (spec) =>
               spec.module_graph_id === activeGraphId &&
               spec.catalog_visible !== false,
-          ) ?? null
+          ) ?? null)
         : null,
     [activeGraphId, registry.nodes],
   );
@@ -1429,7 +1408,9 @@ export function NodeSelector({
   React.useEffect(() => {
     if (open && !wasOpen.current) {
       setQuery("");
-      setFilterId("all");
+      setActiveSourceId("all");
+      setArtifactFilterId(null);
+      setInputNodesOnly(false);
       setSelectedNodeKey(null);
       setSelectedRelease(null);
       setTechnicalDetailsOpen(false);
@@ -1439,28 +1420,27 @@ export function NodeSelector({
   }, [open]);
 
   const normalizedQuery = query.trim().toLowerCase();
-  const filteredNodes = React.useMemo(
-    () => {
-      if (loading || errorMessage) return [];
-      return nodesForBrowserFilter(
-        compatibleCatalogNodes,
-        activeFilter,
-        query,
-        registry,
-      );
-    },
-    [
-      activeFilter,
+  const filteredNodes = React.useMemo(() => {
+    if (loading || errorMessage) return [];
+    return filterAndSearchCatalogNodes(
       compatibleCatalogNodes,
-      errorMessage,
-      loading,
+      [activeSourceFilter, ...refinementFilters],
       query,
       registry,
-    ],
-  );
-  const listedSpec = filteredNodes.find(
-    (spec) => nodeKey(spec) === selectedNodeKey,
-  ) ?? filteredNodes[0] ?? null;
+    );
+  }, [
+    activeSourceFilter,
+    compatibleCatalogNodes,
+    errorMessage,
+    loading,
+    query,
+    refinementFilters,
+    registry,
+  ]);
+  const listedSpec =
+    filteredNodes.find((spec) => nodeKey(spec) === selectedNodeKey) ??
+    filteredNodes[0] ??
+    null;
   const moduleReleases = React.useMemo(
     () =>
       listedSpec?.plugin_slug === MODULE_PLUGIN_SLUG
@@ -1499,17 +1479,18 @@ export function NodeSelector({
       ? compatibilityPortSelection.portKey
       : null;
   const activeCompatibilityPort =
-    compatibilityPorts.find((port) => portKey(port) === compatibilityPortKey)
-    ?? compatibilityPorts[0]
-    ?? null;
+    compatibilityPorts.find((port) => portKey(port) === compatibilityPortKey) ??
+    compatibilityPorts[0] ??
+    null;
   const portMatches = React.useMemo(
-    () => selectedSpec && activeCompatibilityPort
-      ? compatibleNodesForPort(
-          selectedSpec,
-          activeCompatibilityPort,
-          catalogRegistry,
-        )
-      : [],
+    () =>
+      selectedSpec && activeCompatibilityPort
+        ? compatibleNodesForPort(
+            selectedSpec,
+            activeCompatibilityPort,
+            catalogRegistry,
+          )
+        : [],
     [activeCompatibilityPort, catalogRegistry, selectedSpec],
   );
   const selectedPlugin = selectedSpec
@@ -1523,7 +1504,12 @@ export function NodeSelector({
   const selectedPrimaryOutputArtifact = selectedPrimaryOutput
     ? portArtifactType(selectedPrimaryOutput)
     : null;
-  const activeFilterTitle = activeFilter.title;
+  const resultsTitle =
+    activeSourceFilter.id === "all"
+      ? "All nodes"
+      : activeSourceFilter.id === "workspace-library"
+        ? "Workspace library"
+        : `${activeSourceFilter.title} nodes`;
   const isModuleSelection = selectedPlugin?.entry_kind === "module";
   const isDeprecatedModule = selectedSpec?.publication_state === "deprecated";
   const selectionCanInsert = canInsert && selectedSpec?.runnable !== false;
@@ -1537,7 +1523,7 @@ export function NodeSelector({
     ? `node-selector-result-${nodeKey(listedSpec)}`
     : undefined;
   const compatibilityPortTitle = compatibility
-    ? compatibility.port.title ?? compatibility.port.name
+    ? (compatibility.port.title ?? compatibility.port.name)
     : null;
   const resultStatus = loading
     ? "Loading nodes…"
@@ -1547,21 +1533,18 @@ export function NodeSelector({
         ? "No nodes found."
         : `${filteredNodes.length} ${filteredNodes.length === 1 ? "node" : "nodes"}.`;
 
-  const selectFilter = (nextFilter: BrowserFilter) => {
-    setFilterId(nextFilter.id);
+  const selectSource = (id: string) => {
+    setActiveSourceId(id);
     setSelectedNodeKey(null);
     setTechnicalDetailsOpen(false);
     setCompatibilityPortSelection(null);
   };
 
-  const focusFilterAt = (index: number) => {
-    const boundedIndex = Math.max(
-      0,
-      Math.min(index, browserFilters.length - 1),
-    );
-    const nextFilter = browserFilters[boundedIndex];
+  const focusSourceAt = (index: number) => {
+    const boundedIndex = Math.max(0, Math.min(index, sourceFilters.length - 1));
+    const nextFilter = sourceFilters[boundedIndex];
     if (!nextFilter) return;
-    selectFilter(nextFilter);
+    selectSource(nextFilter.id);
     filterRefs.current.get(nextFilter.id)?.focus();
   };
 
@@ -1592,9 +1575,13 @@ export function NodeSelector({
     const key = nodeKey(spec);
     pendingResultFocusKey.current = key;
     setQuery("");
-    setFilterId(
-      spec.plugin_slug === MODULE_PLUGIN_SLUG ? "workspace-library" : "all",
+    setActiveSourceId(
+      spec.plugin_slug === MODULE_PLUGIN_SLUG
+        ? "workspace-library"
+        : sourceFilterId(spec.plugin_slug),
     );
+    setArtifactFilterId(null);
+    setInputNodesOnly(false);
     setSelectedNodeKey(key);
     setSelectedRelease(null);
     setTechnicalDetailsOpen(false);
@@ -1608,7 +1595,13 @@ export function NodeSelector({
     const option = resultRefs.current.get(key);
     option?.scrollIntoView?.({ block: "nearest" });
     option?.focus();
-  }, [filterId, query, selectedNodeKey]);
+  }, [
+    activeSourceId,
+    artifactFilterId,
+    inputNodesOnly,
+    query,
+    selectedNodeKey,
+  ]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -1663,19 +1656,19 @@ export function NodeSelector({
         </div>
 
         <div {...stylex.props(s.layout)}>
-          <nav aria-label="Works with" {...stylex.props(s.filterPane)}>
-            <h3 {...stylex.props(s.filterHeading)}>Works with</h3>
+          <nav aria-label="Node filters" {...stylex.props(s.filterPane)}>
+            <h3 {...stylex.props(s.filterHeading)}>Source</h3>
             <div
               role="toolbar"
-              aria-label="Node filters"
+              aria-label="Node sources"
               aria-orientation={mobileNodeSelector ? "horizontal" : "vertical"}
               {...stylex.props(s.categoryToolbar)}
             >
-              {browserFilters.map((filter, index) => {
-                const active = filter.id === activeFilter.id;
-                const count = nodesForBrowserFilter(
+              {sourceFilters.map((filter, index) => {
+                const active = filter.id === activeSourceId;
+                const count = filterAndSearchCatalogNodes(
                   compatibleCatalogNodes,
-                  filter,
+                  [filter, ...refinementFilters],
                   "",
                   registry,
                 ).length;
@@ -1693,24 +1686,30 @@ export function NodeSelector({
                       s.categoryButton,
                       active ? s.categoryButtonActive : null,
                     )}
-                    onClick={() => selectFilter(filter)}
+                    onClick={() => selectSource(filter.id)}
                     onKeyDown={(event) => {
-                      if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+                      if (
+                        event.key === "ArrowDown" ||
+                        event.key === "ArrowRight"
+                      ) {
                         event.preventDefault();
-                        focusFilterAt(index + 1);
-                      } else if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+                        focusSourceAt(index + 1);
+                      } else if (
+                        event.key === "ArrowUp" ||
+                        event.key === "ArrowLeft"
+                      ) {
                         event.preventDefault();
-                        focusFilterAt(index - 1);
+                        focusSourceAt(index - 1);
                       } else if (event.key === "Home") {
                         event.preventDefault();
-                        focusFilterAt(0);
+                        focusSourceAt(0);
                       } else if (event.key === "End") {
                         event.preventDefault();
-                        focusFilterAt(browserFilters.length - 1);
+                        focusSourceAt(sourceFilters.length - 1);
                       }
                     }}
                   >
-                    <BrowserFilterIcon filter={filter} />
+                    <SourceFilterIcon filter={filter} />
                     {filter.title}
                   </button>
                 );
@@ -1719,23 +1718,57 @@ export function NodeSelector({
                     {filterButton}
                   </div>
                 ) : (
-                  <React.Fragment key={filter.id}>{filterButton}</React.Fragment>
+                  <React.Fragment key={filter.id}>
+                    {filterButton}
+                  </React.Fragment>
                 );
               })}
             </div>
+            <div {...stylex.props(s.refinementSection)}>
+              <label {...stylex.props(s.refinementField)}>
+                <span>Artifact</span>
+                <select
+                  aria-label="Artifact type"
+                  value={artifactFilterId ?? ""}
+                  {...stylex.props(s.refinementSelect)}
+                  onChange={(event) => {
+                    setArtifactFilterId(event.currentTarget.value || null);
+                    setSelectedNodeKey(null);
+                  }}
+                >
+                  <option value="">Any artifact</option>
+                  {artifactOptions.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.title}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label {...stylex.props(s.refinementCheck)}>
+                <input
+                  type="checkbox"
+                  checked={inputNodesOnly}
+                  onChange={(event) => {
+                    setInputNodesOnly(event.currentTarget.checked);
+                    setSelectedNodeKey(null);
+                  }}
+                />
+                Input nodes only
+              </label>
+            </div>
           </nav>
 
-          <section aria-labelledby="node-selector-results-heading" {...stylex.props(s.nodePane)}>
+          <section
+            aria-labelledby="node-selector-results-heading"
+            {...stylex.props(s.nodePane)}
+          >
             <header {...stylex.props(s.nodePaneHeader)}>
               <div {...stylex.props(s.resultHeading)}>
-                <h3 id="node-selector-results-heading" {...stylex.props(s.nodePaneTitle)}>
-                  {activeFilter.id === "all"
-                    ? "All nodes"
-                    : ["text", "images", "tables", "spatial", "prompts"].includes(
-                        activeFilter.id,
-                      )
-                      ? `${activeFilterTitle} nodes`
-                      : activeFilterTitle}
+                <h3
+                  id="node-selector-results-heading"
+                  {...stylex.props(s.nodePaneTitle)}
+                >
+                  {resultsTitle}
                 </h3>
                 <span
                   role={errorMessage ? "alert" : "status"}
@@ -1748,9 +1781,13 @@ export function NodeSelector({
               </div>
             </header>
             {compatibility && compatibilityPortTitle ? (
-              <div id="node-selector-compatibility" {...stylex.props(s.compatibilityBanner)}>
+              <div
+                id="node-selector-compatibility"
+                {...stylex.props(s.compatibilityBanner)}
+              >
                 <Cable size={12} aria-hidden="true" />
-                Showing nodes that can connect {compatibility.direction === "upstream" ? "to" : "from"}{" "}
+                Showing nodes that can connect{" "}
+                {compatibility.direction === "upstream" ? "to" : "from"}{" "}
                 <strong>{compatibilityPortTitle}</strong>.
               </div>
             ) : null}
@@ -1766,79 +1803,91 @@ export function NodeSelector({
                 <div {...stylex.props(s.empty)}>
                   <span>Nodes couldn’t be loaded. {errorMessage}</span>
                   {onRetry ? (
-                    <button type="button" {...stylex.props(s.resetButton)} onClick={onRetry}>
+                    <button
+                      type="button"
+                      {...stylex.props(s.resetButton)}
+                      onClick={onRetry}
+                    >
                       Try again
                     </button>
                   ) : null}
                 </div>
               ) : loading ? (
                 <div {...stylex.props(s.empty)}>Loading nodes…</div>
-              ) : filteredNodes.length ? filteredNodes.map((spec, index) => {
-                const key = nodeKey(spec);
-                const active = listedSpec
-                  ? key === nodeKey(listedSpec)
-                  : false;
-                const representativePort = spec.outputs[0] ?? spec.inputs[0];
-                const representativeArtifact = representativePort
-                  ? portArtifactType(representativePort)
-                  : null;
-                return (
-                  <button
-                    key={key}
-                    id={`node-selector-result-${key}`}
-                    ref={(element) => {
-                      if (element) resultRefs.current.set(key, element);
-                      else resultRefs.current.delete(key);
-                    }}
-                    type="button"
-                    role="option"
-                    tabIndex={active ? 0 : -1}
-                    aria-selected={active}
-                    {...stylex.props(
-                      s.nodeRow,
-                      active ? s.nodeRowActive : null,
-                    )}
-                    style={active && representativeArtifact ? {
-                      borderColor: artifactTypeColor(
-                        representativeArtifact.id,
-                        tokens.colorAccent,
-                      ),
-                    } : undefined}
-                    onClick={() => {
-                      setSelectedNodeKey(key);
-                      setTechnicalDetailsOpen(false);
-                    }}
-                    onFocus={() => setSelectedNodeKey(key)}
-                    onKeyDown={(event) => {
-                      if (event.key === "ArrowDown") {
-                        event.preventDefault();
-                        focusResultAt(index + 1);
-                      } else if (event.key === "ArrowUp") {
-                        event.preventDefault();
-                        focusResultAt(index - 1);
-                      } else if (event.key === "Home") {
-                        event.preventDefault();
-                        focusResultAt(0);
-                      } else if (event.key === "End") {
-                        event.preventDefault();
-                        focusResultAt(filteredNodes.length - 1);
-                      } else if (event.key === "Enter") {
-                        event.preventDefault();
-                        if (selectedSpec) insertNode(selectedSpec);
+              ) : filteredNodes.length ? (
+                filteredNodes.map((spec, index) => {
+                  const key = nodeKey(spec);
+                  const active = listedSpec
+                    ? key === nodeKey(listedSpec)
+                    : false;
+                  const representativePort = spec.outputs[0] ?? spec.inputs[0];
+                  const representativeArtifact = representativePort
+                    ? portArtifactType(representativePort)
+                    : null;
+                  return (
+                    <button
+                      key={key}
+                      id={`node-selector-result-${key}`}
+                      ref={(element) => {
+                        if (element) resultRefs.current.set(key, element);
+                        else resultRefs.current.delete(key);
+                      }}
+                      type="button"
+                      role="option"
+                      tabIndex={active ? 0 : -1}
+                      aria-selected={active}
+                      {...stylex.props(
+                        s.nodeRow,
+                        active ? s.nodeRowActive : null,
+                      )}
+                      style={
+                        active && representativeArtifact
+                          ? {
+                              borderColor: artifactTypeColor(
+                                representativeArtifact.id,
+                                tokens.colorAccent,
+                              ),
+                            }
+                          : undefined
                       }
-                    }}
-                  >
-                    <span {...stylex.props(s.nodeCopy)}>
-                      <span {...stylex.props(s.nodeTitleRow)}>
-                        <span {...stylex.props(s.nodeTitle)}>{spec.title}</span>
+                      onClick={() => {
+                        setSelectedNodeKey(key);
+                        setTechnicalDetailsOpen(false);
+                      }}
+                      onFocus={() => setSelectedNodeKey(key)}
+                      onKeyDown={(event) => {
+                        if (event.key === "ArrowDown") {
+                          event.preventDefault();
+                          focusResultAt(index + 1);
+                        } else if (event.key === "ArrowUp") {
+                          event.preventDefault();
+                          focusResultAt(index - 1);
+                        } else if (event.key === "Home") {
+                          event.preventDefault();
+                          focusResultAt(0);
+                        } else if (event.key === "End") {
+                          event.preventDefault();
+                          focusResultAt(filteredNodes.length - 1);
+                        } else if (event.key === "Enter") {
+                          event.preventDefault();
+                          if (selectedSpec) insertNode(selectedSpec);
+                        }
+                      }}
+                    >
+                      <span {...stylex.props(s.nodeCopy)}>
+                        <span {...stylex.props(s.nodeTitleRow)}>
+                          <span {...stylex.props(s.nodeTitle)}>
+                            {spec.title}
+                          </span>
+                        </span>
+                        <span {...stylex.props(s.nodeDescription)}>
+                          {spec.description || "No description is available."}
+                        </span>
                       </span>
-                      <span {...stylex.props(s.nodeDescription)}>
-                        {spec.description || "No description is available."}
-                      </span>
-                    </span>
-                  </button>
-                );
-              }) : (
+                    </button>
+                  );
+                })
+              ) : (
                 <div {...stylex.props(s.empty)}>
                   <span>
                     {compatibility
@@ -1847,16 +1896,19 @@ export function NodeSelector({
                         ? "No published Modules match the current search."
                         : "No nodes match the current search or filter."}
                   </span>
-                  {normalizedQuery || activeFilter.id !== "all" ? (
+                  {normalizedQuery ||
+                  activeSourceId !== "all" ||
+                  artifactFilterId !== null ||
+                  inputNodesOnly ? (
                     <button
                       type="button"
                       {...stylex.props(s.resetButton)}
                       onClick={() => {
                         setQuery("");
-                        selectFilter(
-                          browserFilters.find((filter) => filter.id === "all") ??
-                            browserFilters[0]!,
-                        );
+                        setActiveSourceId("all");
+                        setArtifactFilterId(null);
+                        setInputNodesOnly(false);
+                        setSelectedNodeKey(null);
                       }}
                     >
                       Reset search and filter
@@ -1901,7 +1953,9 @@ export function NodeSelector({
 
           <aside
             aria-label="Node information"
-            aria-labelledby={selectedSpec ? "node-selector-inspector-title" : undefined}
+            aria-labelledby={
+              selectedSpec ? "node-selector-inspector-title" : undefined
+            }
             {...stylex.props(s.inspector)}
           >
             {selectedSpec && selectedPlugin ? (
@@ -1912,14 +1966,18 @@ export function NodeSelector({
                   className={[
                     stylex.props(s.inspectorBody).className,
                     "grafy-node-detail",
-                  ].filter(Boolean).join(" ")}
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
                 >
                   <div
                     {...stylex.props(s.previewStage)}
                     className={[
                       stylex.props(s.previewStage).className,
                       "grafy-node-preview-stage",
-                    ].filter(Boolean).join(" ")}
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
                   >
                     <CatalogNodePreview
                       spec={selectedSpec}
@@ -1940,242 +1998,303 @@ export function NodeSelector({
                     />
                   </div>
                   <div {...stylex.props(s.inspectorScroll)}>
-                  {isModuleSelection ? (
-                    <header {...stylex.props(s.inspectorHeader)}>
-                      <div {...stylex.props(s.inspectorProvenance)}>
-                        <div {...stylex.props(s.eyebrow)}>
-                          Module · release {selectedSpec.module_graph_revision}
-                        </div>
-                        <span {...stylex.props(s.originBadge)}>
-                          {selectedSpec.publication_state ?? "published"}
-                        </span>
-                      </div>
-                      <h3 id="node-selector-inspector-title" {...stylex.props(s.inspectorTitle)}>
-                        {selectedSpec.title}
-                      </h3>
-                      <div {...stylex.props(s.operatorId)}>
-                        Module contract · release {selectedSpec.module_graph_revision}
-                      </div>
-                      {moduleReleases.length > 1 ? (
-                        <label {...stylex.props(s.operatorId)}>
-                          Release{" "}
-                          <select
-                            aria-label="Module release"
-                            value={nodeKey(selectedSpec)}
-                            onChange={(event) => {
-                              const moduleKey =
-                                listedSpec.module_id ?? listedSpec.module_graph_id;
-                              if (!moduleKey) return;
-                              setSelectedRelease({
-                                moduleKey,
-                                releaseKey: event.currentTarget.value,
-                              });
-                            }}
-                          >
-                            {moduleReleases.map((release) => (
-                              <option key={nodeKey(release)} value={nodeKey(release)}>
-                                Release {release.module_graph_revision}
-                                {release.is_current_library_release ? " (current)" : ""}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      ) : null}
-                      {isDeprecatedModule ? (
-                        <p {...stylex.props(s.moduleDiagnosticsNote)}>
-                          This Module is deprecated. New inserts are discouraged;
-                          existing pins keep working.
-                        </p>
-                      ) : null}
-                      {selectedSpec.module_graph_id && onOpenGraph ? (
-                        <button
-                          type="button"
-                          title="Open the saved graph that defines this module"
-                          {...stylex.props(s.openGraphButton, s.inspectorOpenGraph)}
-                          onClick={() => onOpenGraph(selectedSpec.module_graph_id!)}
-                        >
-                          <ExternalLink size={10} />
-                          Open source graph
-                        </button>
-                      ) : null}
-                      <p {...stylex.props(s.inspectorDescription)}>
-                        {selectedSpec.description || "No description is available for this node."}
-                      </p>
-                      {selectedSpec.runnable === false ? (
-                        <p {...stylex.props(s.moduleDiagnosticsNote)}>
-                          Catalog preview only. {pluginUnavailableReason}
-                        </p>
-                      ) : null}
-                    </header>
-                  ) : (
-                    <header {...stylex.props(s.inspectorHeader)}>
-                      <h3 id="node-selector-inspector-title" {...stylex.props(s.inspectorTitle)}>
-                        {selectedSpec.title}
-                      </h3>
-                      <p {...stylex.props(s.inspectorDescription)}>
-                        {selectedSpec.description || "No description is available for this node."}
-                      </p>
-                      {selectedSpec.runnable === false ? (
-                        <p {...stylex.props(s.moduleDiagnosticsNote)}>
-                          Catalog preview only. {pluginUnavailableReason}
-                        </p>
-                      ) : null}
-                      <div {...stylex.props(s.inspectorSummary)}>
-                        <p {...stylex.props(s.inspectorStatement)}>
-                          {selectedPrimaryInput ? (
-                            <>
-                              Accepts{" "}
-                              <span
-                                {...stylex.props(s.inspectorStatementStrong)}
-                                style={{
-                                  color: selectedPrimaryInputArtifact
-                                    ? artifactTypeColor(
-                                        selectedPrimaryInputArtifact.id,
-                                        tokens.colorTextEmphasis,
-                                      )
-                                    : tokens.colorTextEmphasis,
-                                }}
-                              >
-                                {artifactTitleFor(registry, selectedPrimaryInput)}
-                              </span>
-                              {selectedSpec.inputs.length > 1
-                                ? ` + ${selectedSpec.inputs.length - 1} more`
-                                : ` · ${selectedPrimaryInput.shape === "many" ? "sequence" : "single value"}`}
-                            </>
-                          ) : "Starts a workflow"}
-                        </p>
-                        <p {...stylex.props(s.inspectorStatement)}>
-                          {selectedPrimaryOutput ? (
-                            <>
-                              Produces{" "}
-                              <span
-                                {...stylex.props(s.inspectorStatementStrong)}
-                                style={{
-                                  color: selectedPrimaryOutputArtifact
-                                    ? artifactTypeColor(
-                                        selectedPrimaryOutputArtifact.id,
-                                        tokens.colorTextEmphasis,
-                                      )
-                                    : tokens.colorTextEmphasis,
-                                }}
-                              >
-                                {artifactTitleFor(registry, selectedPrimaryOutput)}
-                              </span>
-                              {selectedSpec.outputs.length > 1
-                                ? ` + ${selectedSpec.outputs.length - 1} more`
-                                : ` · ${selectedPrimaryOutput.shape === "many" ? "sequence" : "single value"}`}
-                            </>
-                          ) : "Ends a workflow branch"}
-                        </p>
-                        <div {...stylex.props(s.inspectorConfiguration)}>
-                          <span {...stylex.props(s.inspectorConfigurationLabel)}>
-                            Configuration:
-                          </span>
-                          <span>
-                            {selectedFields.length
-                              ? `${selectedFields.map((field) => field.title).join(", ")} ${selectedFields.length === 1 ? "is" : "are"} editable after adding.`
-                              : "No editable settings."}
+                    {isModuleSelection ? (
+                      <header {...stylex.props(s.inspectorHeader)}>
+                        <div {...stylex.props(s.inspectorProvenance)}>
+                          <div {...stylex.props(s.eyebrow)}>
+                            Module · release{" "}
+                            {selectedSpec.module_graph_revision}
+                          </div>
+                          <span {...stylex.props(s.originBadge)}>
+                            {selectedSpec.publication_state ?? "published"}
                           </span>
                         </div>
-                        <button
-                          type="button"
-                          aria-expanded={technicalDetailsOpen}
-                          {...stylex.props(s.technicalToggle)}
-                          onClick={() => setTechnicalDetailsOpen((open) => !open)}
+                        <h3
+                          id="node-selector-inspector-title"
+                          {...stylex.props(s.inspectorTitle)}
                         >
-                          {technicalDetailsOpen
-                            ? "Hide technical details"
-                            : "View technical details"}
-                        </button>
-                      </div>
-                    </header>
-                  )}
-
-                  {isModuleSelection || technicalDetailsOpen ? (
-                    <>
-                      <section {...stylex.props(s.section)}>
-                        <div {...stylex.props(s.sectionTitleRow)}>
-                          <Workflow size={13} {...stylex.props(s.sectionIcon)} />
-                          <h3 {...stylex.props(s.sectionTitle)}>
-                            {isModuleSelection ? "Module contract" : "Ports"}
-                          </h3>
+                          {selectedSpec.title}
+                        </h3>
+                        <div {...stylex.props(s.operatorId)}>
+                          Module contract · release{" "}
+                          {selectedSpec.module_graph_revision}
                         </div>
-                        {!isModuleSelection ? (
+                        {moduleReleases.length > 1 ? (
+                          <label {...stylex.props(s.operatorId)}>
+                            Release{" "}
+                            <select
+                              aria-label="Module release"
+                              value={nodeKey(selectedSpec)}
+                              onChange={(event) => {
+                                const moduleKey =
+                                  listedSpec.module_id ??
+                                  listedSpec.module_graph_id;
+                                if (!moduleKey) return;
+                                setSelectedRelease({
+                                  moduleKey,
+                                  releaseKey: event.currentTarget.value,
+                                });
+                              }}
+                            >
+                              {moduleReleases.map((release) => (
+                                <option
+                                  key={nodeKey(release)}
+                                  value={nodeKey(release)}
+                                >
+                                  Release {release.module_graph_revision}
+                                  {release.is_current_library_release
+                                    ? " (current)"
+                                    : ""}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                        ) : null}
+                        {isDeprecatedModule ? (
                           <p {...stylex.props(s.moduleDiagnosticsNote)}>
-                            {selectedSpec.operator_id}@{selectedSpec.operator_version}
+                            This Module is deprecated. New inserts are
+                            discouraged; existing pins keep working.
                           </p>
                         ) : null}
-                        <div {...stylex.props(s.portGrid)}>
-                          <PortList
-                            direction="input"
-                            ports={selectedSpec.inputs}
-                            registry={registry}
-                          />
-                          <PortList
-                            direction="output"
-                            ports={selectedSpec.outputs}
-                            registry={registry}
-                          />
-                        </div>
-                      </section>
-
-                      <section {...stylex.props(s.section)}>
-                        <div {...stylex.props(s.sectionTitleRow)}>
-                          <Settings2 size={13} {...stylex.props(s.sectionIcon)} />
-                          <h3 {...stylex.props(s.sectionTitle)}>Configuration</h3>
-                        </div>
-                        {selectedFields.length ? (
-                          <div {...stylex.props(s.fieldList)}>
-                            {selectedFields.map((field) => (
-                              <div key={field.name} {...stylex.props(s.fieldRow)}>
-                                <div {...stylex.props(s.fieldIdentity)}>
-                                  <div {...stylex.props(s.fieldTitle)}>{field.title}</div>
-                                  <div {...stylex.props(s.fieldName)}>{field.name}</div>
-                                </div>
-                                <div {...stylex.props(s.fieldDetails)}>
-                                  <div {...stylex.props(s.fieldMeta)}>
-                                    {fieldTypeLabel(field)} · {fieldConstraintLabel(field)}
-                                  </div>
-                                  {field.description ? (
-                                    <p {...stylex.props(s.fieldDescription)}>{field.description}</p>
-                                  ) : null}
-                                  {field.enumValues?.length ? (
-                                    <p {...stylex.props(s.fieldChoices)}>
-                                      Choices: {field.enumValues.map(String).join(", ")}
-                                    </p>
-                                  ) : null}
-                                  {field.pattern ? (
-                                    <p {...stylex.props(s.fieldChoices)}>Pattern: {field.pattern}</p>
-                                  ) : null}
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-                        ) : (
-                          <p {...stylex.props(s.compatibilityEmpty)}>
-                            No editable scalar settings are declared. Upload or custom controls, when available, appear on the node after it is added.
+                        {selectedSpec.module_graph_id && onOpenGraph ? (
+                          <button
+                            type="button"
+                            title="Open the saved graph that defines this module"
+                            {...stylex.props(
+                              s.openGraphButton,
+                              s.inspectorOpenGraph,
+                            )}
+                            onClick={() =>
+                              onOpenGraph(selectedSpec.module_graph_id!)
+                            }
+                          >
+                            <ExternalLink size={10} />
+                            Open source graph
+                          </button>
+                        ) : null}
+                        <p {...stylex.props(s.inspectorDescription)}>
+                          {selectedSpec.description ||
+                            "No description is available for this node."}
+                        </p>
+                        {selectedSpec.runnable === false ? (
+                          <p {...stylex.props(s.moduleDiagnosticsNote)}>
+                            Catalog preview only. {pluginUnavailableReason}
                           </p>
-                        )}
-                      </section>
-                    </>
-                  ) : null}
+                        ) : null}
+                      </header>
+                    ) : (
+                      <header {...stylex.props(s.inspectorHeader)}>
+                        <h3
+                          id="node-selector-inspector-title"
+                          {...stylex.props(s.inspectorTitle)}
+                        >
+                          {selectedSpec.title}
+                        </h3>
+                        <p {...stylex.props(s.inspectorDescription)}>
+                          {selectedSpec.description ||
+                            "No description is available for this node."}
+                        </p>
+                        {selectedSpec.runnable === false ? (
+                          <p {...stylex.props(s.moduleDiagnosticsNote)}>
+                            Catalog preview only. {pluginUnavailableReason}
+                          </p>
+                        ) : null}
+                        <div {...stylex.props(s.inspectorSummary)}>
+                          <p {...stylex.props(s.inspectorStatement)}>
+                            {selectedPrimaryInput ? (
+                              <>
+                                Accepts{" "}
+                                <span
+                                  {...stylex.props(s.inspectorStatementStrong)}
+                                  style={{
+                                    color: selectedPrimaryInputArtifact
+                                      ? artifactTypeColor(
+                                          selectedPrimaryInputArtifact.id,
+                                          tokens.colorTextEmphasis,
+                                        )
+                                      : tokens.colorTextEmphasis,
+                                  }}
+                                >
+                                  {artifactTitleFor(
+                                    registry,
+                                    selectedPrimaryInput,
+                                  )}
+                                </span>
+                                {selectedSpec.inputs.length > 1
+                                  ? ` + ${selectedSpec.inputs.length - 1} more`
+                                  : ` · ${selectedPrimaryInput.shape === "many" ? "sequence" : "single value"}`}
+                              </>
+                            ) : (
+                              "Starts a workflow"
+                            )}
+                          </p>
+                          <p {...stylex.props(s.inspectorStatement)}>
+                            {selectedPrimaryOutput ? (
+                              <>
+                                Produces{" "}
+                                <span
+                                  {...stylex.props(s.inspectorStatementStrong)}
+                                  style={{
+                                    color: selectedPrimaryOutputArtifact
+                                      ? artifactTypeColor(
+                                          selectedPrimaryOutputArtifact.id,
+                                          tokens.colorTextEmphasis,
+                                        )
+                                      : tokens.colorTextEmphasis,
+                                  }}
+                                >
+                                  {artifactTitleFor(
+                                    registry,
+                                    selectedPrimaryOutput,
+                                  )}
+                                </span>
+                                {selectedSpec.outputs.length > 1
+                                  ? ` + ${selectedSpec.outputs.length - 1} more`
+                                  : ` · ${selectedPrimaryOutput.shape === "many" ? "sequence" : "single value"}`}
+                              </>
+                            ) : (
+                              "Ends a workflow branch"
+                            )}
+                          </p>
+                          <div {...stylex.props(s.inspectorConfiguration)}>
+                            <span
+                              {...stylex.props(s.inspectorConfigurationLabel)}
+                            >
+                              Configuration:
+                            </span>
+                            <span>
+                              {selectedFields.length
+                                ? `${selectedFields.map((field) => field.title).join(", ")} ${selectedFields.length === 1 ? "is" : "are"} editable after adding.`
+                                : "No editable settings."}
+                            </span>
+                          </div>
+                          <button
+                            type="button"
+                            aria-expanded={technicalDetailsOpen}
+                            {...stylex.props(s.technicalToggle)}
+                            onClick={() =>
+                              setTechnicalDetailsOpen((open) => !open)
+                            }
+                          >
+                            {technicalDetailsOpen
+                              ? "Hide technical details"
+                              : "View technical details"}
+                          </button>
+                        </div>
+                      </header>
+                    )}
 
-                  {activeCompatibilityPort ? (
-                    <WorksWithSection
-                      ports={compatibilityPorts}
-                      activePort={activeCompatibilityPort}
-                      matches={portMatches}
-                      registry={registry}
-                      onSelectPort={(port) => {
-                        if (!selectedSpecKey) return;
-                        setCompatibilityPortSelection({
-                          specKey: selectedSpecKey,
-                          portKey: portKey(port),
-                        });
-                      }}
-                      onInspect={inspectCatalogNode}
-                    />
-                  ) : null}
+                    {isModuleSelection || technicalDetailsOpen ? (
+                      <>
+                        <section {...stylex.props(s.section)}>
+                          <div {...stylex.props(s.sectionTitleRow)}>
+                            <Workflow
+                              size={13}
+                              {...stylex.props(s.sectionIcon)}
+                            />
+                            <h3 {...stylex.props(s.sectionTitle)}>
+                              {isModuleSelection ? "Module contract" : "Ports"}
+                            </h3>
+                          </div>
+                          {!isModuleSelection ? (
+                            <p {...stylex.props(s.moduleDiagnosticsNote)}>
+                              {selectedSpec.operator_id}@
+                              {selectedSpec.operator_version}
+                            </p>
+                          ) : null}
+                          <div {...stylex.props(s.portGrid)}>
+                            <PortList
+                              direction="input"
+                              ports={selectedSpec.inputs}
+                              registry={registry}
+                            />
+                            <PortList
+                              direction="output"
+                              ports={selectedSpec.outputs}
+                              registry={registry}
+                            />
+                          </div>
+                        </section>
+
+                        <section {...stylex.props(s.section)}>
+                          <div {...stylex.props(s.sectionTitleRow)}>
+                            <Settings2
+                              size={13}
+                              {...stylex.props(s.sectionIcon)}
+                            />
+                            <h3 {...stylex.props(s.sectionTitle)}>
+                              Configuration
+                            </h3>
+                          </div>
+                          {selectedFields.length ? (
+                            <div {...stylex.props(s.fieldList)}>
+                              {selectedFields.map((field) => (
+                                <div
+                                  key={field.name}
+                                  {...stylex.props(s.fieldRow)}
+                                >
+                                  <div {...stylex.props(s.fieldIdentity)}>
+                                    <div {...stylex.props(s.fieldTitle)}>
+                                      {field.title}
+                                    </div>
+                                    <div {...stylex.props(s.fieldName)}>
+                                      {field.name}
+                                    </div>
+                                  </div>
+                                  <div {...stylex.props(s.fieldDetails)}>
+                                    <div {...stylex.props(s.fieldMeta)}>
+                                      {fieldTypeLabel(field)} ·{" "}
+                                      {fieldConstraintLabel(field)}
+                                    </div>
+                                    {field.description ? (
+                                      <p {...stylex.props(s.fieldDescription)}>
+                                        {field.description}
+                                      </p>
+                                    ) : null}
+                                    {field.enumValues?.length ? (
+                                      <p {...stylex.props(s.fieldChoices)}>
+                                        Choices:{" "}
+                                        {field.enumValues
+                                          .map(String)
+                                          .join(", ")}
+                                      </p>
+                                    ) : null}
+                                    {field.pattern ? (
+                                      <p {...stylex.props(s.fieldChoices)}>
+                                        Pattern: {field.pattern}
+                                      </p>
+                                    ) : null}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          ) : (
+                            <p {...stylex.props(s.compatibilityEmpty)}>
+                              No editable scalar settings are declared. Upload
+                              or custom controls, when available, appear on the
+                              node after it is added.
+                            </p>
+                          )}
+                        </section>
+                      </>
+                    ) : null}
+
+                    {activeCompatibilityPort ? (
+                      <WorksWithSection
+                        ports={compatibilityPorts}
+                        activePort={activeCompatibilityPort}
+                        matches={portMatches}
+                        registry={registry}
+                        onSelectPort={(port) => {
+                          if (!selectedSpecKey) return;
+                          setCompatibilityPortSelection({
+                            specKey: selectedSpecKey,
+                            portKey: portKey(port),
+                          });
+                        }}
+                        onInspect={inspectCatalogNode}
+                      />
+                    ) : null}
                   </div>
                 </div>
 
@@ -2191,15 +2310,17 @@ export function NodeSelector({
                   <button
                     type="button"
                     disabled={!selectionCanInsert}
-                    aria-describedby={!selectionCanInsert
-                      ? "node-selector-insert-disabled-reason"
-                      : undefined}
+                    aria-describedby={
+                      !selectionCanInsert
+                        ? "node-selector-insert-disabled-reason"
+                        : undefined
+                    }
                     title={
                       !selectionCanInsert
                         ? selectionDisabledReason
                         : isModuleSelection
-                        ? `Insert module call for ${selectedSpec.title}`
-                        : `Add ${selectedSpec.title} to the workflow`
+                          ? `Insert module call for ${selectedSpec.title}`
+                          : `Add ${selectedSpec.title} to the workflow`
                     }
                     {...stylex.props(
                       s.addButton,


### PR DESCRIPTION
## Summary
- Replace the node browser's artifact-family rail (Text / Images / Tables / Spatial / Prompts / Sequences) with categories scoped by source: All, one per provider plugin that ships nodes, and Workspace library, built dynamically from the registry via `buildSourceFilters`.
- Add an artifact-type refinement — a select of "Any artifact" plus every registered artifact type — that narrows results within the active source.
- Add an "Input nodes only" filter for nodes that take no inputs because they are inputs themselves (e.g. "Enter text").
- Extend the catalog filter model with `source` and `input-nodes` kinds (`sourceKey` on `CatalogFilter`, `sourceFilterId`, `INPUT_NODES_FILTER`); `filterAndSearchCatalogNodes` now accepts multiple filters and intersects them, composing with the search query and port-compatibility context.

## Testing
- `npm run typecheck` in `apps/web` — clean
- `npx vitest run` in `apps/web` — 584 passed (86 files)
- `npx eslint` on the four changed files — clean
- New/updated coverage: `node-catalog.test.ts` (source categories, source/input-node matching, source × artifact × input-node intersection) and `NodeSelector.test.tsx` (source rail, artifact select, input-node toggle)
